### PR TITLE
changed to o = OWL.ontology to o = OWL.Ontology

### DIFF
--- a/Notebooks/01-00-Program-your-TBox.ipynb
+++ b/Notebooks/01-00-Program-your-TBox.ipynb
@@ -59,7 +59,7 @@
    "source": [
     "s = URIRef( \"https://example.org/myFamousOntology\" )\n",
     "p = RDF.type\n",
-    "o = OWL.ontology\n",
+    "o = OWL.Ontology\n",
     "g.add( ( s , p , o ) )"
    ]
   },


### PR DESCRIPTION
Ontology in OWL should have a capital O. 